### PR TITLE
Add "About" and "Glossary" pages to site

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -7,6 +7,12 @@
       }
     }
   ],
+  "replacementPatterns": [
+    {
+      "pattern": "^/",
+      "replacement": "https://inoplatforms.info/"
+    }
+  ],
   "retryOn429": true,
   "retryCount": 3,
   "aliveStatusCodes": [200, 206]

--- a/site/content/about/_index.md
+++ b/site/content/about/_index.md
@@ -1,0 +1,72 @@
+---
+title: About
+breadcrumb: about
+layout: page
+page-type: static
+---
+
+**inoplatforms** is a catalog of all known Arduino boards platforms.
+
+## About Arduino
+
+The term "[**Arduino**](https://www.arduino.cc/)" is used when referring to various things; a company, a community, development hardware, a firmware framework. At the heart of all these things is the idea of making [embedded systems](https://wikipedia.org/wiki/Embedded_system) accessible; offering everyone the opportunity to create things with [microcontrollers](https://wikipedia.org/wiki/Microcontroller).
+
+## About Arduino Hardware
+
+Arduino projects may created from a completely custom circuit built from base components, or built around a manufactured [development board](/glossary/#development-board). A diverse array of microcontrollers and development boards may be used.
+
+The microcontrollers range from the relatively limited (e.g., [ATtiny13](https://www.microchip.com/product/attiny13)) to high performance cutting edge technology (e.g., [STM32H7](https://wikipedia.org/wiki/STM32#STM32_H7)).
+
+In addition to [the products](https://docs.arduino.cc/) manufactured by the Arduino company, many more development boards have been created by other companies and the community. These boards typically provide the basic support circuitry for the primary microcontroller, convenient electrical interface, hardware programming interface, and sometimes include components (e.g., radio communication module, sensors) that add supplemental capabilities.
+
+## About Arduino Tooling
+
+The diversity of target hardware comes with a similar diversity of [toolchains](https://wikipedia.org/wiki/Toolchain). Arduino development software such as [**Arduino IDE**](https://docs.arduino.cc/software/ide-v2) provide a convenient high level user interface that allows the user to easily perform common operations such as compiling and uploading programs without needing to work with the individual toolchains directly.
+
+## About Arduino Firmware
+
+Each target microcontroller has its own complex and obscure low level firmware programming interface. One of the cornerstones of the Arduino initiative is a standardized firmware code [API](https://wikipedia.org/wiki/API) that provides an [abstraction layer](https://wikipedia.org/wiki/Abstraction_layer) over the architecture-specific low level interface. Ideally, a program that uses this API can run on any target.
+
+### Arduino Cores
+
+The code that implements the [fundamental Arduino firmware API](https://www.arduino.cc/reference/en/) for a given target is referred to as a "[core](https://arduino.github.io/arduino-cli/latest/platform-specification/#cores)".
+
+### Arduino Libraries
+
+Reusable firmware code may be packaged in an [Arduino library](https://arduino.github.io/arduino-cli/latest/library-specification/).
+
+## About Arduino Platforms
+
+An [Arduino platform](https://arduino.github.io/arduino-cli/latest/platform-specification/) contains everything needed to add support for a given target to the Arduino development software. This includes the configuration definitions that allow the development software to generate the appropriate toolchain commands, the Arduino core(s), and [supplemental libraries](https://arduino.github.io/arduino-cli/latest/platform-specification/#platform-bundled-libraries).
+
+---
+
+**ⓘ** Platforms are often [incorrectly](https://arduino.github.io/arduino-cli/latest/platform-specification/#platform-terminology) referred to as "cores". Although a platform may include a core, the core is only one component of a platform.
+
+---
+
+## About the **inoplatforms** Project
+
+The Arduino hardware ecosystem is bounded by the array of available Arduino boards platforms. Although the platforms by prominent entities and for popular targets are well known, hundreds more lesser known platforms are also available. The goal of the **inoplatforms** project is to make it easier for the Arduino community to discover valuable and interesting platforms. This is done by providing a free, open source, comprehensive catalog of Arduino platforms.
+
+More information about **inoplatforms** is available from the [**project repository readme**](https://github.com/per1234/inoplatforms#readme).
+
+---
+
+⚠ **inoplatforms** is a catalog of _every_ unique or significant Arduino platform in existence. Presence in the catalog does not in any way imply a platform is adequate or even functional.
+
+The suitability and safety of platforms should be carefully evaluated by the user before installation and usage.
+
+Source data provided by the catalog will assist in such evaluations.
+
+---
+
+## More Information
+
+- [**Glossary**](/glossary/)
+- [**Project documentation**](https://github.com/per1234/inoplatforms#readme)
+- [**Arduino Platform Specification**](https://arduino.github.io/arduino-cli/latest/platform-specification/)
+- [**Arduino Package Index Specification**](https://arduino.github.io/arduino-cli/latest/package_index_json-specification/)
+- [**Arduino IDE Boards Manager tutorial**](https://docs.arduino.cc/software/ide-v2/tutorials/ide-v2-board-manager)
+- [**Arduino CLI `core` command documentation**](https://arduino.github.io/arduino-cli/latest/commands/arduino-cli_core/)
+- [**Discuss Arduino boards platforms on Arduino Forum**](https://forum.arduino.cc/)

--- a/site/content/glossary/_index.md
+++ b/site/content/glossary/_index.md
@@ -1,0 +1,154 @@
+---
+title: Glossary
+breadcrumb: glossary
+layout: page
+page-type: static
+---
+
+## Arduino development software
+
+Application that facilitates the development and deployment of Arduino firmware programs.
+
+More information [**here** (Arduino CLI)](https://arduino.github.io/arduino-cli/latest/) and [**here** (Arduino IDE)](https://docs.arduino.cc/software/ide-v2).
+
+## board
+
+A target embedded system. The target could be a [development board](#development-board) or [microcontroller](#microcontroller) alone.
+
+## Boards Manager
+
+A component of Arduino development software for managing installation and updates of platforms.
+
+More information [**here** (Arduino CLI)](https://arduino.github.io/arduino-cli/latest/commands/arduino-cli_core/) and [**here** (Arduino IDE)](https://docs.arduino.cc/software/ide-v2/tutorials/ide-v2-board-manager).
+
+## core
+
+Code that implements the [fundamental Arduino firmware API](https://www.arduino.cc/reference/en/) for a given target.
+
+More information [**here**](https://arduino.github.io/arduino-cli/latest/platform-specification/#cores).
+
+## development board
+
+Hardware used as a target during development and prototyping of an embedded system device. This is a [PCB](https://wikipedia.org/wiki/Printed_circuit_board) with a [microcontroller](#microcontroller), essential support circuitry, and additional electronic components. Development boards are manufactured by the Arduino company as well as 3rd parties, or created DIY by users.
+
+More information [**here**](https://docs.arduino.cc/).
+
+## Git
+
+Version control system.
+
+More information [**here**](https://git-scm.com/).
+
+## GitHub
+
+Popular website that provides [Git](#git) [repository](#repository) hosting, enhanced with additional collaboration and social features.
+
+More information [**here**](https://docs.github.com/en/get-started).
+
+## host
+
+The environment in which a [tool](#tool) will run.
+
+## library
+
+A collection of reusable firmware code.
+
+More information [**here**](https://arduino.github.io/arduino-cli/latest/library-specification/).
+
+## Library Manager
+
+A component of Arduino development software for managing installation and updates of standalone Arduino libraries. Not directly relevant to Arduino platforms or this project, but sometimes confused with [**Boards Manager**](#boards-manager).
+
+More information [**here** (Arduino CLI)](https://arduino.github.io/arduino-cli/latest/commands/arduino-cli_lib/) and [**here** (Arduino IDE)](https://docs.arduino.cc/software/ide-v2/tutorials/ide-v2-installing-a-library#installing-a-library).
+
+## microcontroller
+
+A small, inexpensive, power efficient computer packaged in an [integrated circuit](https://wikipedia.org/wiki/Integrated_circuit).
+
+More information [**here**](https://wikipedia.org/wiki/Microcontroller).
+
+## package
+
+A collection of Arduino [platforms](#platform) and/or [tools](#tool).
+
+## package index
+
+Provides the data that allows a platform to be installed via [**Boards Manager**](#boards-manager).
+
+More information [**here**](https://arduino.github.io/arduino-cli/latest/package_index_json-specification/).
+
+## package provider
+
+Term used in the **inoplatforms** project to refer to any source of Arduino [packages](#package). This will ideally be a [package index](#package-index), but also applies to cases where a platform creator did not provide a package index.
+
+## packager
+
+The maintainer of an Arduino [package](#package).
+
+---
+
+**ⓘ** The term "package" is used exclusively in the **inoplatforms** project.
+
+---
+
+## platform
+
+Provides everything needed to add support for a given target to the Arduino development software. This includes the configuration definitions that allow the [development software](#arduino-development-software) to generate the appropriate [tool](#tool) invocation commands, [cores](#core), and [libraries](#platform-bundled-library).
+
+---
+
+**ⓘ** Platforms are often [incorrectly](https://arduino.github.io/arduino-cli/latest/platform-specification/#platform-terminology) referred to as "cores". Although a platform may ([optionally](https://arduino.github.io/arduino-cli/latest/platform-specification/#core-reference)) include a [core](#core), the core is only one of the components of a platform.
+
+---
+
+More information [**here**](https://arduino.github.io/arduino-cli/latest/platform-specification/).
+
+## platform bundled library
+
+An [Arduino library](#library) that is included in the installation of a platform. A platform bundled library is only accessible when compiling for a board of its platform.
+
+More information [**here**](https://arduino.github.io/arduino-cli/latest/platform-specification/#platform-bundled-libraries).
+
+## pluggable discovery
+
+A specific type of [tool](#tool) that provides Arduino development software with a list of ports of a given protocol that might be used for communication between the PC and an Arduino board.
+
+More information [**here**](https://arduino.github.io/arduino-cli/latest/pluggable-discovery-specification/).
+
+## pluggable monitor
+
+A specific type of [tool](#tool) that provides the low level interface between Arduino development software and an Arduino board for arbitrary communications by the user. The user interface that wraps this communication in **Arduino IDE** is named [**Serial Monitor**](https://docs.arduino.cc/software/ide-v2/tutorials/ide-v2-serial-monitor) (which, despite the "serial" in the name, can be used for communication via any protocol thanks to the pluggable monitor system).
+
+More information [**here**](https://arduino.github.io/arduino-cli/latest/pluggable-monitor-specification/).
+
+## release
+
+A versioned offering of a [platform](#platform) or [tool](#tool) at a specific point in its development history.
+
+## repository
+
+A project under version control.
+
+More information [**here**](https://wikipedia.org/wiki/Repository_%28version_control%29).
+
+## tool
+
+An application used by the Arduino development software to perform a given process (e.g., compilation, upload) for a given target board.
+
+More information [**here**](https://arduino.github.io/arduino-cli/latest/package_index_json-specification/#tools-definitions).
+
+## tool dependency
+
+The specification of a platform's dependency on a [tool](#tool).
+
+More information [**here**](https://arduino.github.io/arduino-cli/latest/package_index_json-specification/#platforms-definitions).
+
+## vendor
+
+An alternative term for "[packager](#packager)".
+
+---
+
+**ⓘ** The term "package" is used exclusively in the **inoplatforms** project.
+
+---

--- a/site/hugo.yml
+++ b/site/hugo.yml
@@ -19,6 +19,13 @@ markup:
       hardWraps: true
       unsafe: true
 
+menu:
+  main:
+    - identifier: about
+      name: About
+      url: /about/
+      weight: 10
+
 module:
   imports:
     - path: github.com/adityatelange/hugo-PaperMod


### PR DESCRIPTION
These pages explain the project and content to site visitors.