### PR TITLE
Configure SVGLint to run all rules

### DIFF
--- a/.github/workflows/check-svg-task.yml
+++ b/.github/workflows/check-svg-task.yml
@@ -5,6 +5,7 @@ on:
   create:
   push:
     paths:
+      - ".svglintrc.js"
       - "go.mod"
       - "go.sum"
       - "package.json"
@@ -13,6 +14,7 @@ on:
       - "**.svg"
   pull_request:
     paths:
+      - ".svglintrc.js"
       - "go.mod"
       - "go.sum"
       - "package.json"

--- a/.svglintrc.js
+++ b/.svglintrc.js
@@ -1,0 +1,8 @@
+// See: https://github.com/birjj/svglint#config
+module.exports = {
+  rules: {
+    attr: true,
+    elm: true,
+    valid: true,
+  },
+};

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -565,4 +565,4 @@ tasks:
             npx \
               svglint \
                 '{}' \
-            + \
+            +


### PR DESCRIPTION
By default, SVGLint only runs the "valid" rule set. By adding a custom configuration file to the repository, the
additional "attr" and "elm" rule sets can be enabled for more comprehensive validation of the project's SVG files.