### PR TITLE
Correct `layout` values in site content front matter

### DIFF
--- a/site/content/about/_index.md
+++ b/site/content/about/_index.md
@@ -1,7 +1,7 @@
 ---
 title: About
 breadcrumb: about
-layout: page
+layout: basic
 page-type: static
 ---
 

--- a/site/content/glossary/_index.md
+++ b/site/content/glossary/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Glossary
 breadcrumb: glossary
-layout: page
+layout: basic
 page-type: static
 ---
 

--- a/site/layouts/partials/secondary-header.html
+++ b/site/layouts/partials/secondary-header.html
@@ -1,4 +1,5 @@
 <header style="margin-bottom: 15px;">
+  {{- partial "breadcrumbs.html" . }}
   <h1 class="post-title">
     {{- .Title }}
   </h1>


### PR DESCRIPTION
The value in the `layout` field of the website content source file front matter must match the name of the layout template file.

These pages were incorrectly configured to use a layout named "page" even though no such layout exists. They are hereby changed to use the "basic" layout as originally intended.