### PR TITLE
Correct domain for site links

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -10,7 +10,7 @@
   "replacementPatterns": [
     {
       "pattern": "^/",
-      "replacement": "https://inoplatforms.info/"
+      "replacement": "https://www.inoplatforms.info/"
     }
   ],
   "retryOn429": true,

--- a/site/hugo.yml
+++ b/site/hugo.yml
@@ -1,7 +1,7 @@
 # See: https://gohugo.io/getting-started/configuration/
 
 title: Arduino Platforms
-baseURL: http://inoplatforms.info
+baseURL: https://www.inoplatforms.info
 languageCode: en-us
 
 markup:


### PR DESCRIPTION
The website is at the domain www.inoplatforms.info.

Ideally, the website could always be referred to as the more concise "inoplatforms.info". A redirect is set up from inoplatforms.info to www.inoplatforms.info, but there are several problems with using this domain in links:

* It only works if the `http` scheme is used in the URL. The redirect doesn't work if the `https` scheme is used.
* It always points to the root path, even if the source url pointed to a sub-path in the site (e.g., http://inoplatforms.info/about redirects to https://www.inoplatforms.info instead of https://www.inoplatforms.info/about)
* It makes the page load take longer (due to the redirection taking some time)

For this reason, www.inoplatforms.info should always be used in site links.