### PR TITLE
Document use of IDE fallback for "Name" column value

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The list can be viewed online [here](ino-hardware-package-list.tsv).
 
 ### Columns
 
-- **Name**: The package index `packages[].platforms[].name` value, the platform.txt `name` property value, or an arbitrary name determined from looking at the repository content.
+- **Name**: The package index `packages[].platforms[].name` value, the platform.txt `name` property value, or the `{vendor}-{architecture}` name used by Arduino IDE as a fallback.
 - **Vendor**: The package index `packages[].name` value or the name of the platform's vendor folder. The machine-friendly name of the package is `{vendor}:{architecture}`.
 - **Architecture**: The package index `packages[].platforms[].architecture` value or the name of the platform's architecture folder. The machine-friendly name of the package is `{vendor}:{architecture}`.
 - **Repository**: URL of the repository where the platform source files are hosted.


### PR DESCRIPTION
It makes sense for the catalog to obtain the platform name from the same sources of data as is used by Arduino development tools. Previously, the documentation of the usage of the catalog spreadsheet's "Name" column correctly specified the use of the first two of these sources, but then resorted to the use of an arbitrary name as the fallback.

The documentation of the "Name" column is hereby updated to specify the use of a name based on the platform vendor and architecture values as fallback. This now aligns with the behavior of Arduino IDE.